### PR TITLE
Feature - Add OpenTelemetry Logging with Serilog

### DIFF
--- a/ConwaysGameOfLife.sln
+++ b/ConwaysGameOfLife.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.github\workflows\sonar_pull_request.yml = .github\workflows\sonar_pull_request.yml
 		otel-collector-config.yml = otel-collector-config.yml
 		.dockerignore = .dockerignore
+		grafana-datasources.yml = grafana-datasources.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{229E1888-0DAC-4F7C-A9D6-9AF3F94C293D}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,26 @@ services:
       - "14250:14250"
       - "6831:6831/udp"
 
+  loki:
+    container_name: loki
+    image: grafana/loki:latest
+    command: ["-config.file=/etc/loki/local-config.yaml"]
+    ports:
+      - "3100:3100"
+
+  grafana:
+    container_name: grafana
+    image: grafana/grafana
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana-datasources.yml:/etc/grafana/provisioning/datasources/datasources.yaml
+
   collector:
     container_name: collector
     image: otel/opentelemetry-collector-contrib:0.103.1
@@ -28,12 +48,21 @@ services:
     ports:
       - "4317:4317"
       - "4318:4318"
+      - "8888:8888"
+      - "8889:8889"
+      - "13133:13133"
+      - "8090"
     volumes:
       - ./otel-collector-config.yml:/etc/otel-collector-config.yml
     depends_on:
-      - jaeger  
+      - jaeger
+      - loki
+      - grafana
 
 volumes:
   postgres_data:
     name: postgres_data
+    external: false
+  grafana_data:
+    name: grafana_data
     external: false

--- a/grafana-datasources.yml
+++ b/grafana-datasources.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    orgId: 1
+    url: http://loki:3100
+    basicAuth: false
+    isDefault: false
+    version: 1
+    editable: true
+    uid: loki

--- a/otel-collector-config.yml
+++ b/otel-collector-config.yml
@@ -18,10 +18,24 @@ processors:
         - 'attributes["url.path"] == "/swagger/swagger-ui-standalone-preset.js"'
         - 'attributes["url.path"] == "/swagger/swagger-ui-bundle.js"'
         - 'attributes["url.path"] == "/swagger/swagger-ui.css"'
+  attributes:
+    actions:
+      - action: insert
+        key: loki.attribute.labels
+        value: event.domain
+  resource:
+    attributes:
+      - action: insert
+        key: loki.resource.labels
+        value: service.name, service.namespace
 
 exporters:
   otlp:
     endpoint: jaeger:4317
+    tls:
+      insecure: true
+  loki:
+    endpoint: http://loki:3100/loki/api/v1/push
     tls:
       insecure: true
 
@@ -31,3 +45,7 @@ service:
       receivers: [otlp]
       processors: [batch, filter]
       exporters: [otlp]
+    logs:
+      receivers: [otlp]
+      processors: [attributes, resource]
+      exporters: [loki]

--- a/src/Conways.GameOfLife.API/Behaviors/LoggingBehavior.cs
+++ b/src/Conways.GameOfLife.API/Behaviors/LoggingBehavior.cs
@@ -1,0 +1,40 @@
+using Conways.GameOfLife.Infrastructure.Extensions;
+using MediatR;
+
+namespace Conways.GameOfLife.API.Behaviors;
+
+public class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IBaseRequest
+    where TResponse : notnull
+{
+    private readonly ILogger<LoggingBehavior<TRequest,TResponse>> _logger;
+
+    public LoggingBehavior(ILogger<LoggingBehavior<TRequest, TResponse>> logger)
+    {
+        _logger = logger;
+    }
+    
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        var behaviorName = typeof(LoggingBehavior<TRequest, TResponse>).GetGenericTypeName();
+
+        var requestType = typeof(TRequest);
+
+        try
+        {
+            _logger.LogInformation("[{Behavior}] - Handling request of type {RequestType}", behaviorName, requestType);
+
+            var response = await next().ConfigureAwait(continueOnCapturedContext: false);
+
+            _logger.LogInformation("[{Behavior}] - Request of type {RequestType} handled successfully", behaviorName, requestType);
+
+            return response;
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "[{Behavior}] - An exception occurred while handling request of type {RequestType}", behaviorName, requestType);
+
+            throw;
+        }
+    }
+}

--- a/src/Conways.GameOfLife.API/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Conways.GameOfLife.API/Extensions/ServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ public static class ServiceCollectionExtensions
         return services.AddMediatR(config =>
         {
             config.RegisterServicesFromAssemblyContaining<Program>();
+            config.AddOpenBehavior(typeof(LoggingBehavior<,>));
             config.AddOpenBehavior(typeof(ValidationBehavior<,>));
             config.Lifetime = ServiceLifetime.Scoped;
         });

--- a/src/Conways.GameOfLife.API/Program.cs
+++ b/src/Conways.GameOfLife.API/Program.cs
@@ -14,6 +14,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Configuration
     .AddEnvironmentVariables();
 
+builder.Logging.AddSerilogLogging(builder.Configuration);
+
 builder.Services
     .AddBoardDbContext(builder.Configuration)
     .AddHashIds(builder.Configuration)

--- a/src/Conways.GameOfLife.Infrastructure/Conways.GameOfLife.Infrastructure.csproj
+++ b/src/Conways.GameOfLife.Infrastructure/Conways.GameOfLife.Infrastructure.csproj
@@ -13,6 +13,9 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1"/>
+        <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+        <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="3.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Conways.GameOfLife.Infrastructure/Extensions/LoggingBuilderExtensions.cs
+++ b/src/Conways.GameOfLife.Infrastructure/Extensions/LoggingBuilderExtensions.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Sinks.OpenTelemetry;
+
+namespace Conways.GameOfLife.Infrastructure.Extensions;
+
+[ExcludeFromCodeCoverage]
+public static class LoggingBuilderExtensions
+{
+    public static ILoggingBuilder AddSerilogLogging(this ILoggingBuilder builder, IConfiguration configuration)
+    {
+        var serviceName = configuration.GetValue<string>("SERVICE_NAME");
+        var serviceVersion = configuration.GetValue<string>("SERVICE_VERSION");
+        var exporterEndpoint = configuration.GetValue<string>("EXPORTER_ENDPOINT");
+        
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceVersion);
+        ArgumentException.ThrowIfNullOrWhiteSpace(exporterEndpoint);
+        
+        builder.ClearProviders();
+
+        var logger = new LoggerConfiguration()
+            .Enrich.WithProperty("service_name", serviceName)
+            .Enrich.WithProperty("service_version", serviceVersion)
+            .WriteTo.OpenTelemetry(options =>
+            {
+                options.Endpoint = exporterEndpoint;
+                options.Protocol = OtlpProtocol.Grpc;
+                options.ResourceAttributes = new Dictionary<string, object>
+                {
+                    ["service.name"] = serviceName,
+                    ["service.version"] = serviceVersion
+                };
+            })
+            .WriteTo.Conditional(_ => Debugger.IsAttached, sink => sink.Console())
+            .CreateLogger();
+
+        Log.Logger = logger;
+        
+        builder.AddSerilog(logger);
+
+        return builder;
+    }
+}

--- a/src/Conways.GameOfLife.Infrastructure/Extensions/MatrixExtensions.cs
+++ b/src/Conways.GameOfLife.Infrastructure/Extensions/MatrixExtensions.cs
@@ -1,0 +1,67 @@
+using Conways.GameOfLife.Domain;
+
+namespace Conways.GameOfLife.Infrastructure.Extensions;
+
+public static class MatrixExtensions
+{
+    public static T[,] ToMultiArray<T>(this T[][] array)
+    {
+        var rows = array.Length;
+        
+        var columns = array[0].Length;
+        
+        var multiArray = new T[rows, columns];
+        
+        for (var i = 0; i < rows; i++)
+        {
+            for (var j = 0; j < columns; j++)
+            {
+                multiArray[i, j] = array[i][j];
+            }
+        }
+        
+        return multiArray;
+    }
+
+    public static T[][] ToMatrix<T>(this T[,] array)
+    {
+        var rows = array.GetLength(0);
+        
+        var columns = array.GetLength(1);
+        
+        var matrix = new T[rows][];
+        
+        for (var i = 0; i < rows; i++)
+        {
+            matrix[i] = new T[columns];
+            
+            for (var j = 0; j < columns; j++)
+            {
+                matrix[i][j] = array[i, j];
+            }
+        }
+        
+        return matrix;
+    }
+    
+    public static bool[][] ToMatrix(this Generation generation)
+    {
+        var rows = generation.GetRows();
+        
+        var columns = generation.GetColumns();
+        
+        var matrix = new bool[rows][];
+        
+        for (var i = 0; i < rows; i++)
+        {
+            matrix[i] = new bool[columns];
+            
+            for (var j = 0; j < columns; j++)
+            {
+                matrix[i][j] = generation[i, j];
+            }
+        }
+        
+        return matrix;
+    }
+}

--- a/src/Conways.GameOfLife.Infrastructure/Extensions/TypeExtensions.cs
+++ b/src/Conways.GameOfLife.Infrastructure/Extensions/TypeExtensions.cs
@@ -1,67 +1,15 @@
-using Conways.GameOfLife.Domain;
-
 namespace Conways.GameOfLife.Infrastructure.Extensions;
 
 public static class TypeExtensions
 {
-    public static T[,] ToMultiArray<T>(this T[][] array)
+    public static string GetGenericTypeName(this Type type)
     {
-        var rows = array.Length;
-        
-        var columns = array[0].Length;
-        
-        var multiArray = new T[rows, columns];
-        
-        for (var i = 0; i < rows; i++)
-        {
-            for (var j = 0; j < columns; j++)
-            {
-                multiArray[i, j] = array[i][j];
-            }
-        }
-        
-        return multiArray;
-    }
+        if (!type.IsGenericType) return type.Name;
 
-    public static T[][] ToMatrix<T>(this T[,] array)
-    {
-        var rows = array.GetLength(0);
-        
-        var columns = array.GetLength(1);
-        
-        var matrix = new T[rows][];
-        
-        for (var i = 0; i < rows; i++)
-        {
-            matrix[i] = new T[columns];
-            
-            for (var j = 0; j < columns; j++)
-            {
-                matrix[i][j] = array[i, j];
-            }
-        }
-        
-        return matrix;
-    }
-    
-    public static bool[][] ToMatrix(this Generation generation)
-    {
-        var rows = generation.GetRows();
-        
-        var columns = generation.GetColumns();
-        
-        var matrix = new bool[rows][];
-        
-        for (var i = 0; i < rows; i++)
-        {
-            matrix[i] = new bool[columns];
-            
-            for (var j = 0; j < columns; j++)
-            {
-                matrix[i][j] = generation[i, j];
-            }
-        }
-        
-        return matrix;
+        var genericTypes = string.Join(",", type.GetGenericArguments().Select(argument => argument.Name));
+
+        var genericTypeName = $"{type.Name.Replace("`", string.Empty)}<{genericTypes}>";
+
+        return genericTypeName;
     }
 }

--- a/tests/Conways.GameOfLife.IntegrationTests/Factories/ConwaysGameOfLifeWebApplicationFactory.cs
+++ b/tests/Conways.GameOfLife.IntegrationTests/Factories/ConwaysGameOfLifeWebApplicationFactory.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.Configuration;
-
 namespace Conways.GameOfLife.IntegrationTests.Factories;
 
 // ReSharper disable once ClassNeverInstantiated.Global


### PR DESCRIPTION
# Conway's Game of Life - OpenTelemetry Logging with Serilog

This PR adds logging to the application using OpenTelemetry and Serilog. OpenTelemetry collector then sends the logs to Loki which can be inspected through Grafana.

## Checklist :white_check_mark:

- [x] My code adheres to the project's style guidelines.
- [x] I have reviewed my code thoroughly.
- [ ] I have updated the documentation accordingly.
- [x] My changes do not introduce any new warnings.
- [x] I have added tests to verify the effectiveness of my fix or feature.
- [x] All new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## How Has This Been Tested? :test_tube:

Running the application and visualizing logs using Grafana.