### PR TITLE
Feature - Readonly Db Context

### DIFF
--- a/src/Conways.GameOfLife.API/Features/FinalGeneration/FinalGenerationQueryHandler.cs
+++ b/src/Conways.GameOfLife.API/Features/FinalGeneration/FinalGenerationQueryHandler.cs
@@ -10,10 +10,10 @@ namespace Conways.GameOfLife.API.Features.FinalGeneration;
 
 public class FinalGenerationQueryHandler : IRequestHandler<FinalGenerationQuery, FinalGenerationResponse>
 {
-    private readonly BoardDbContext _context;
+    private readonly BoardDbContextReadOnly _context;
     private readonly IHashids _hashids;
 
-    public FinalGenerationQueryHandler(BoardDbContext context, IHashids hashids)
+    public FinalGenerationQueryHandler(BoardDbContextReadOnly context, IHashids hashids)
     {
         _context = context;
         _hashids = hashids;
@@ -25,7 +25,6 @@ public class FinalGenerationQueryHandler : IRequestHandler<FinalGenerationQuery,
 
         var board = await _context.Set<Board>()
             .Include("_generations")
-            .AsNoTracking()
             .FirstOrDefaultAsync(b => b.Id == boardId, cancellationToken)
             .ConfigureAwait(continueOnCapturedContext: false);
 

--- a/src/Conways.GameOfLife.API/Features/NextGeneration/NextGenerationQueryHandler.cs
+++ b/src/Conways.GameOfLife.API/Features/NextGeneration/NextGenerationQueryHandler.cs
@@ -10,10 +10,10 @@ namespace Conways.GameOfLife.API.Features.NextGeneration;
 
 public class NextGenerationQueryHandler : IRequestHandler<NextGenerationQuery, NextGenerationResponse>
 {
-    private readonly BoardDbContext _context;
+    private readonly BoardDbContextReadOnly _context;
     private readonly IHashids _hashids;
 
-    public NextGenerationQueryHandler(BoardDbContext context, IHashids hashids)
+    public NextGenerationQueryHandler(BoardDbContextReadOnly context, IHashids hashids)
     {
         _context = context;
         _hashids = hashids;
@@ -25,7 +25,6 @@ public class NextGenerationQueryHandler : IRequestHandler<NextGenerationQuery, N
 
         var board = await _context.Set<Board>()
             .Include("_generations")
-            .AsNoTracking()
             .FirstOrDefaultAsync(b => b.Id == boardId, cancellationToken)
             .ConfigureAwait(continueOnCapturedContext: false);
 

--- a/src/Conways.GameOfLife.API/Features/NextGenerations/NextGenerationsQueryHandler.cs
+++ b/src/Conways.GameOfLife.API/Features/NextGenerations/NextGenerationsQueryHandler.cs
@@ -10,10 +10,10 @@ namespace Conways.GameOfLife.API.Features.NextGenerations;
 
 public class NextGenerationsQueryHandler : IRequestHandler<NextGenerationsQuery, NextGenerationsResponse>
 {
-    private readonly BoardDbContext _context;
+    private readonly BoardDbContextReadOnly _context;
     private readonly IHashids _hashids;
 
-    public NextGenerationsQueryHandler(BoardDbContext context, IHashids hashids)
+    public NextGenerationsQueryHandler(BoardDbContextReadOnly context, IHashids hashids)
     {
         _context = context;
         _hashids = hashids;
@@ -25,7 +25,6 @@ public class NextGenerationsQueryHandler : IRequestHandler<NextGenerationsQuery,
 
         var board = await _context.Set<Board>()
             .Include("_generations")
-            .AsNoTracking()
             .FirstOrDefaultAsync(b => b.Id == boardId, cancellationToken)
             .ConfigureAwait(continueOnCapturedContext: false);
 

--- a/src/Conways.GameOfLife.API/Program.cs
+++ b/src/Conways.GameOfLife.API/Program.cs
@@ -17,7 +17,7 @@ builder.Configuration
 builder.Logging.AddSerilogLogging(builder.Configuration);
 
 builder.Services
-    .AddBoardDbContext(builder.Configuration)
+    .AddBoardDbContexts(builder.Configuration)
     .AddHashIds(builder.Configuration)
     .AddCQRS()
     .AddFluentValidators()

--- a/src/Conways.GameOfLife.Infrastructure.PostgreSQL/BoardDbContextReadOnly.cs
+++ b/src/Conways.GameOfLife.Infrastructure.PostgreSQL/BoardDbContextReadOnly.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Conways.GameOfLife.Infrastructure.PostgreSQL;
+
+public sealed class BoardDbContextReadOnly : DbContext
+{
+    public BoardDbContextReadOnly(DbContextOptions<BoardDbContextReadOnly> options) : base(options)
+    {
+        ChangeTracker.AutoDetectChangesEnabled = false;
+        ChangeTracker.LazyLoadingEnabled = false;
+        ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(BoardDbContextReadOnly).Assembly);
+    }
+}

--- a/src/Conways.GameOfLife.Infrastructure.PostgreSQL/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Conways.GameOfLife.Infrastructure.PostgreSQL/Extensions/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Conways.GameOfLife.Infrastructure.PostgreSQL.Interceptors;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -5,26 +6,45 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Conways.GameOfLife.Infrastructure.PostgreSQL.Extensions;
 
+[ExcludeFromCodeCoverage]
 public static class ServiceCollectionExtensions
 {
-    public static IServiceCollection AddBoardDbContext(this IServiceCollection services, IConfiguration configuration)
+    public static IServiceCollection AddBoardDbContexts(this IServiceCollection services, IConfiguration configuration)
     {
         var connectionString = configuration.GetConnectionString(nameof(BoardDbContext));
-
+        
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        
         var retries = configuration.GetValue<int>("PostgresSettings:RetryCount");
 
-        services.AddDbContext<BoardDbContext>((provider, builder) =>
+        services.AddBoardDbContext<BoardDbContext>(connectionString, retries);
+        
+        services.AddBoardDbContext<BoardDbContextReadOnly>(connectionString, retries, useInterceptors: false);
+        
+        return services;
+    }
+
+    private static IServiceCollection AddBoardDbContext<TDbContext>(
+        this IServiceCollection services,
+        string connectionString,
+        int retries,
+        bool useInterceptors = true)
+        where TDbContext : DbContext
+    {
+        services.AddDbContext<TDbContext>((provider, builder) =>
         {
             builder.UseNpgsql(connectionString, pgsql =>
             {
                 pgsql.EnableRetryOnFailure(retries);
             });
 
+            if (!useInterceptors) return;
+            
             var interceptors = InterceptorsAssemblyScanner.Scan(provider, typeof(BoardDbContext).Assembly);
 
             builder.AddInterceptors(interceptors);
         });
-        
+
         return services;
     }
 }


### PR DESCRIPTION
# Title

This PR adds an instance of the Readonly DB Context used for queries. This implies that `AsNoTracking()` can be safely removed.

## Checklist :white_check_mark:

- [x] My code adheres to the project's style guidelines.
- [x] I have reviewed my code thoroughly.
- [ ] I have updated the documentation accordingly.
- [x] My changes do not introduce any new warnings.
- [x] I have added tests to verify the effectiveness of my fix or feature.
- [x] All new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## How Has This Been Tested? :test_tube:

Running the integration tests and interacting with app, same behavior.