### PR TITLE
Feature - Add API Versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ The Swagger UI with https support should be available at https://localhost:7203/
 
 This API has 4 endpoints:
 
-- POST `/api/boards`: creates a new board.
-- GET `/api/boards/{boardId}/generations/final`: given a maximum number of attempts it tries to find the final generation (stable state).
-- GET `/api/boards/{boardId}/generations/next`: returns the next generation of the board (2nd gen is gen 1, gen 0 the first when you post the board).
-- GET `/api/boards/{boardId}/generations/{generations}`: return the x number of generations after gen 0.
+- POST `/api/v1/boards`: creates a new board.
+- GET `/api/v1/boards/{boardId}/generations/final`: given a maximum number of attempts it tries to find the final generation (stable state).
+- GET `/api/v1/boards/{boardId}/generations/next`: returns the next generation of the board (2nd gen is gen 1, gen 0 the first when you post the board).
+- GET `/api/v1/boards/{boardId}/generations/{generations}`: return the x number of generations after gen 0.
 
 **Note**
 

--- a/src/Conways.GameOfLife.API/Conways.GameOfLife.API.csproj
+++ b/src/Conways.GameOfLife.API/Conways.GameOfLife.API.csproj
@@ -12,6 +12,8 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
+      <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
       <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
       <PackageReference Include="MediatR" Version="12.3.0" />
       <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />

--- a/src/Conways.GameOfLife.API/Features/CreateBoard/CreateBoardWebApplicationExtensions.cs
+++ b/src/Conways.GameOfLife.API/Features/CreateBoard/CreateBoardWebApplicationExtensions.cs
@@ -1,15 +1,25 @@
+using System.Net;
+using Asp.Versioning;
+using Conways.GameOfLife.API.Models;
+
 namespace Conways.GameOfLife.API.Features.CreateBoard;
 
 public static class CreateBoardWebApplicationExtensions
 {
-    public static WebApplication MapUploadBoardEndpoint(this WebApplication app)
+    public static RouteGroupBuilder MapCreateBoardEndpoint(this RouteGroupBuilder group, ApiVersion version)
     {
-        app.MapPost("/api/boards", CreateBoardEndpoint.PostAsync)
+        const string contentType = "application/json";
+        
+        group.MapPost("/boards", CreateBoardEndpoint.PostAsync)
             .WithName("CreateNewBoard")
             .WithDisplayName("Create New Board")
             .WithOpenApi()
-            .WithTags("Create a New Board");
+            .WithTags("Create a New Board")
+            .MapToApiVersion(version)
+            .Produces<CreateBoardResponse>(contentType: contentType)
+            .Produces<ErrorResponse>((int)HttpStatusCode.BadRequest, contentType)
+            .Produces<ErrorResponse>((int)HttpStatusCode.InternalServerError, contentType);
         
-        return app;
+        return group;
     }
 }

--- a/src/Conways.GameOfLife.API/Features/FinalGeneration/FinalGenerationWebApplicationExtensions.cs
+++ b/src/Conways.GameOfLife.API/Features/FinalGeneration/FinalGenerationWebApplicationExtensions.cs
@@ -1,15 +1,27 @@
+using System.Net;
+using Asp.Versioning;
+using Conways.GameOfLife.API.Models;
+
 namespace Conways.GameOfLife.API.Features.FinalGeneration;
 
 public static class FinalGenerationWebApplicationExtensions
 {
-    public static WebApplication MapFinalGenerationEndpoint(this WebApplication app)
+    public static RouteGroupBuilder MapFinalGenerationEndpoint(this RouteGroupBuilder group, ApiVersion version)
     {
-        app.MapGet("/api/boards/{boardId}/generations/final", FinalGenerationEndpoint.GetAsync)
+        const string contentType = "application/json";
+        
+        group.MapGet("/boards/{boardId}/generations/final", FinalGenerationEndpoint.GetAsync)
             .WithName("GetFinalGeneration")
             .WithDisplayName("Get Board Final Generation After x Attempts")
             .WithOpenApi()
-            .WithTags("Get Board's Final Generation");
+            .WithTags("Get Board's Final Generation")
+            .MapToApiVersion(version)
+            .Produces<FinalGenerationResponse>(contentType: contentType)
+            .Produces<ErrorResponse>((int)HttpStatusCode.BadRequest, contentType)
+            .Produces<ErrorResponse>((int)HttpStatusCode.NotFound, contentType)
+            .Produces<ErrorResponse>((int)HttpStatusCode.UnprocessableEntity, contentType)
+            .Produces<ErrorResponse>((int)HttpStatusCode.InternalServerError, contentType);
         
-        return app;
+        return group;
     }
 }

--- a/src/Conways.GameOfLife.API/Features/NextGeneration/NextGenerationWebApplicationExtensions.cs
+++ b/src/Conways.GameOfLife.API/Features/NextGeneration/NextGenerationWebApplicationExtensions.cs
@@ -1,15 +1,26 @@
+using System.Net;
+using Asp.Versioning;
+using Conways.GameOfLife.API.Models;
+
 namespace Conways.GameOfLife.API.Features.NextGeneration;
 
 public static class NextGenerationWebApplicationExtensions
 {
-    public static WebApplication MapNextGenerationEndpoint(this WebApplication app)
+    public static RouteGroupBuilder MapNextGenerationEndpoint(this RouteGroupBuilder group, ApiVersion version)
     {
-        app.MapGet("/api/boards/{boardId}/generations/next", NextGenerationEndpoint.GetAsync)
-            .WithName("GetNextGeneration")
-            .WithDisplayName("Get Board Next Generation")
-            .WithOpenApi()
-            .WithTags("Get Board's Next Generation");
+        const string contentType = "application/json";
         
-        return app;
+        group.MapGet(pattern: "/boards/{boardId}/generations/next", handler: NextGenerationEndpoint.GetAsync)
+            .WithName(endpointName: "GetNextGeneration")
+            .WithDisplayName(displayName: "Get Board Next Generation")
+            .WithOpenApi()
+            .WithTags(tags: "Get Board's Next Generation")
+            .MapToApiVersion(apiVersion: version)
+            .Produces<NextGenerationResponse>(contentType: contentType)
+            .Produces<ErrorResponse>((int)HttpStatusCode.BadRequest, contentType)
+            .Produces<ErrorResponse>((int)HttpStatusCode.NotFound, contentType)
+            .Produces<ErrorResponse>((int)HttpStatusCode.InternalServerError, contentType);
+
+        return group;
     }
 }

--- a/src/Conways.GameOfLife.API/Features/NextGenerations/NextGenerationsWebApplicationExtensions.cs
+++ b/src/Conways.GameOfLife.API/Features/NextGenerations/NextGenerationsWebApplicationExtensions.cs
@@ -1,15 +1,26 @@
+using System.Net;
+using Asp.Versioning;
+using Conways.GameOfLife.API.Models;
+
 namespace Conways.GameOfLife.API.Features.NextGenerations;
 
 public static class NextGenerationsWebApplicationExtensions
 {
-    public static WebApplication MapNextGenerationsEndpoint(this WebApplication app)
+    public static RouteGroupBuilder MapNextGenerationsEndpoint(this RouteGroupBuilder group, ApiVersion version)
     {
-        app.MapGet("/api/boards/{boardId}/generations/{generations:int}", NextGenerationsEndpoint.GetAsync)
+        const string contentType = "application/json";
+        
+        group.MapGet("/boards/{boardId}/generations/{generations:int}", NextGenerationsEndpoint.GetAsync)
             .WithName("GetNextGenerations")
             .WithDisplayName("Get Board Next x Generations")
             .WithOpenApi()
-            .WithTags("Get Board's Next x Generation");
+            .WithTags("Get Board's Next x Generation")
+            .MapToApiVersion(version)
+            .Produces<NextGenerationsResponse>(contentType: contentType)
+            .Produces<ErrorResponse>((int)HttpStatusCode.BadRequest, contentType)
+            .Produces<ErrorResponse>((int)HttpStatusCode.NotFound, contentType)
+            .Produces<ErrorResponse>((int)HttpStatusCode.InternalServerError, contentType);
         
-        return app;
+        return group;
     }
 }

--- a/src/Conways.GameOfLife.API/Middlewares/ExceptionMiddleware.cs
+++ b/src/Conways.GameOfLife.API/Middlewares/ExceptionMiddleware.cs
@@ -15,7 +15,7 @@ public class ExceptionMiddleware : IMiddleware
     {
         try
         {
-            await next(context);
+            await next(context).ConfigureAwait(continueOnCapturedContext: false);
         }
         catch (Exception exception)
         {

--- a/src/Conways.GameOfLife.Infrastructure.PostgreSQL/Interceptors/DateTimeSaveChangesInterceptor.cs
+++ b/src/Conways.GameOfLife.Infrastructure.PostgreSQL/Interceptors/DateTimeSaveChangesInterceptor.cs
@@ -6,7 +6,7 @@ namespace Conways.GameOfLife.Infrastructure.PostgreSQL.Interceptors;
 
 public class DateTimeSaveChangesInterceptor : SaveChangesInterceptor
 {
-    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+    public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(
         DbContextEventData eventData,
         InterceptionResult<int> result,
         CancellationToken cancellationToken = new CancellationToken())
@@ -33,6 +33,7 @@ public class DateTimeSaveChangesInterceptor : SaveChangesInterceptor
             }
         }
         
-        return base.SavingChangesAsync(eventData, result, cancellationToken);
+        return await base.SavingChangesAsync(eventData, result, cancellationToken)
+            .ConfigureAwait(continueOnCapturedContext: false);
     }
 }

--- a/tests/Conways.GameOfLife.IntegrationTests/Features/CreateBoard/CreateBoardTests.cs
+++ b/tests/Conways.GameOfLife.IntegrationTests/Features/CreateBoard/CreateBoardTests.cs
@@ -74,7 +74,7 @@ public class CreateBoardTests : IClassFixture<ConwaysGameOfLifeWebApplicationFac
         var jsonString = JsonSerializer.Serialize(new CreateBoardCommand(firstGeneration));
         
         // Act
-        var response = await client.PostAsync("/api/boards", new StringContent(jsonString, Encoding.UTF8, "application/json"));
+        var response = await client.PostAsync("/api/v1/boards", new StringContent(jsonString, Encoding.UTF8, "application/json"));
         
         var body = await response.Content.ReadFromJsonAsync<CreateBoardResponse>();
 

--- a/tests/Conways.GameOfLife.IntegrationTests/Features/FinalGeneration/FinalGenerationTests.cs
+++ b/tests/Conways.GameOfLife.IntegrationTests/Features/FinalGeneration/FinalGenerationTests.cs
@@ -174,7 +174,7 @@ public class FinalGenerationTests : IClassFixture<ConwaysGameOfLifeWebApplicatio
         });
         
         // Act
-        var response = await client.GetAsync($"/api/boards/{boardId}/generations/final?maxAttempts={maxAttempts}");
+        var response = await client.GetAsync($"/api/v1/boards/{boardId}/generations/final?maxAttempts={maxAttempts}");
 
         var body = await response.Content.ReadFromJsonAsync<FinalGenerationResponse>();
 
@@ -217,7 +217,7 @@ public class FinalGenerationTests : IClassFixture<ConwaysGameOfLifeWebApplicatio
         });
         
         // Act
-        var response = await client.GetAsync($"/api/boards/{boardId}/generations/final");
+        var response = await client.GetAsync($"/api/v1/boards/{boardId}/generations/final");
 
         var body = await response.Content.ReadFromJsonAsync<FinalGenerationResponse>();
 
@@ -252,7 +252,7 @@ public class FinalGenerationTests : IClassFixture<ConwaysGameOfLifeWebApplicatio
         });
         
         // Act
-        var response = await client.GetAsync($"/api/boards/{boardId}/generations/final?maxAttempts={maxAttempts}");
+        var response = await client.GetAsync($"/api/v1/boards/{boardId}/generations/final?maxAttempts={maxAttempts}");
 
         var body = await response.Content.ReadFromJsonAsync<ErrorResponse>();
 

--- a/tests/Conways.GameOfLife.IntegrationTests/Features/NextGeneration/NextGenerationTests.cs
+++ b/tests/Conways.GameOfLife.IntegrationTests/Features/NextGeneration/NextGenerationTests.cs
@@ -128,7 +128,7 @@ public class NextGenerationTests : IClassFixture<ConwaysGameOfLifeWebApplication
         });
         
         // Act
-        var response = await client.GetAsync($"/api/boards/{boardId}/generations/next");
+        var response = await client.GetAsync($"/api/v1/boards/{boardId}/generations/next");
 
         var body = await response.Content.ReadFromJsonAsync<NextGenerationResponse>();
 
@@ -154,7 +154,7 @@ public class NextGenerationTests : IClassFixture<ConwaysGameOfLifeWebApplication
         var boardId = hashIds.EncodeLong(1234);
         
         // Act
-        var response = await client.GetAsync($"/api/boards/{boardId}/generations/next");
+        var response = await client.GetAsync($"/api/v1/boards/{boardId}/generations/next");
 
         var body = await response.Content.ReadFromJsonAsync<ErrorResponse>();
 

--- a/tests/Conways.GameOfLife.IntegrationTests/Features/NextGenerations/NextGenerationsTests.cs
+++ b/tests/Conways.GameOfLife.IntegrationTests/Features/NextGenerations/NextGenerationsTests.cs
@@ -121,7 +121,7 @@ public class NextGenerationsTests : IClassFixture<ConwaysGameOfLifeWebApplicatio
         });
         
         // Act
-        var response = await client.GetAsync($"/api/boards/{boardId}/generations/{5}");
+        var response = await client.GetAsync($"/api/v1/boards/{boardId}/generations/{5}");
 
         var body = await response.Content.ReadFromJsonAsync<NextGenerationsResponse>();
 
@@ -148,7 +148,7 @@ public class NextGenerationsTests : IClassFixture<ConwaysGameOfLifeWebApplicatio
         var boardId = hashIds.EncodeLong(1234);
         
         // Act
-        var response = await client.GetAsync($"/api/boards/{boardId}/generations/{5}");
+        var response = await client.GetAsync($"/api/v1/boards/{boardId}/generations/{5}");
 
         var body = await response.Content.ReadFromJsonAsync<ErrorResponse>();
 


### PR DESCRIPTION
# Conway's Game of Live - Add API Versioning

This PR adds the packages `Asp.Versioning.Http` and `Asp.Versioning.Mvc.ApiExplorer` to the API project and configures endpoints to add the `/v1/` to the request path.

## Checklist :white_check_mark:

- [x] My code adheres to the project's style guidelines.
- [x] I have reviewed my code thoroughly.
- [x] I have updated the documentation accordingly.
- [x] My changes do not introduce any new warnings.
- [x] I have added tests to verify the effectiveness of my fix or feature.
- [x] All new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## How Has This Been Tested? :test_tube:

- Run the API, check that version is available at Swagger UI.
- Run the integration tests and add `/v1/` to the request path.